### PR TITLE
Fix Resolve-Path exceptions, allow multiple es.exe install locations

### DIFF
--- a/Binary Wrapper/Get-ESSearchResult.ps1
+++ b/Binary Wrapper/Get-ESSearchResult.ps1
@@ -48,7 +48,7 @@ function Get-ESSearchResult {
         [switch]$AsObject
     )
     $esPath = 'C:\Program Files*\es\es.exe'
-    if (!(Test-Path (Resolve-Path $esPath).Path)){
+    if (!(Resolve-Path $esPath) -or !(Test-Path (Resolve-Path $esPath).Path)){
         Write-Warning "Everything commandline es.exe could not be found on the system please download and install via http://www.voidtools.com/es.zip"
         exit
     }

--- a/Binary Wrapper/Get-ESSearchResult.ps1
+++ b/Binary Wrapper/Get-ESSearchResult.ps1
@@ -50,7 +50,7 @@ function Get-ESSearchResult {
     $esPath = 'C:\Program Files*\es\es.exe'
     if (!(Resolve-Path $esPath) -or !(Test-Path (Resolve-Path $esPath).Path)){
         Write-Warning "Everything commandline es.exe could not be found on the system please download and install via http://www.voidtools.com/es.zip"
-        exit
+        break
     }
 	$result = & (Resolve-Path $esPath).Path $SearchTerm
     if($result.Count -gt 1){

--- a/Binary Wrapper/Get-ESSearchResult.ps1
+++ b/Binary Wrapper/Get-ESSearchResult.ps1
@@ -47,12 +47,20 @@ function Get-ESSearchResult {
         [switch]$OpenFolder,
         [switch]$AsObject
     )
-    $esPath = 'C:\Program Files*\es\es.exe'
-    if (!(Resolve-Path $esPath) -or !(Test-Path (Resolve-Path $esPath).Path)){
-        Write-Warning "Everything commandline es.exe could not be found on the system please download and install via http://www.voidtools.com/es.zip"
+    $esPaths = @('C:\Program Files*\es\es.exe','c:\ProgramData\chocolatey\bin\es.exe')
+    foreach($esPath in $esPaths){
+        $esPath = (Resolve-Path $esPath -ErrorAction SilentlyContinue)
+        if (!$esPath -or !(Test-Path $esPath.Path)){
+            $esPath = ""
+        } else {
+            break
+        }
+    }
+    if ($esPath -eq ""){
+        Write-Warning "Everything commandline es.exe could not be found on the system please download and install via http://www.voidtools.com/es.zip or using Chocolatey ('choco install everything')"
         break
     }
-	$result = & (Resolve-Path $esPath).Path $SearchTerm
+    $result = & $esPath.Path $SearchTerm
     if($result.Count -gt 1){
         $result = $result | Out-GridView -PassThru
     }


### PR DESCRIPTION
On my new machine I used Chocolatey as a package manager and ended up having es.exe in a different location. The *Get-ESSearchResult.ps1* script then failed on many levels:
- instead of the warning I only got an exception, because Resolve-Path cannot resolve non-existing paths
- instead of stopping the script, my shell window did close completely, due to the *exit* command
- after fixing these issues I added support for multiple es.exe install locations
- update the warning to include the Chocolatey command 